### PR TITLE
CI統合チェックジョブを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,18 @@ jobs:
             exit 1
           fi
           echo "Build successful: dist directory exists"
+
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    needs: [python-quality, frontend-build]
+    if: always()
+
+    steps:
+      - name: Check all jobs status
+        run: |
+          if [ "${{ needs.python-quality.result }}" != "success" ] || [ "${{ needs.frontend-build.result }}" != "success" ]; then
+            echo "One or more CI jobs failed"
+            exit 1
+          fi
+          echo "All CI jobs passed successfully"


### PR DESCRIPTION
## 概要
全CIジョブの成否を確認する統合チェックジョブを追加します。

## 変更内容
### 新規ジョブ: `ci-success`
- すべてのCIジョブ (`python-quality`, `frontend-build`) の完了を待機
- すべてのジョブが成功した場合のみ成功
- ブランチ保護ルールで使用可能

## メリット
- ブランチ保護ルールで「CI Success」チェックを必須にするだけで、すべてのCIジョブが成功したことを保証
- 個別のジョブを追加・削除しても、保護ルールの変更が不要
- PRのステータスが一目で分かりやすい

## テスト計画
- [ ] このPRでCI Successジョブが正常に実行されることを確認
- [ ] すべてのジョブが成功した場合にCI Successも成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)